### PR TITLE
미인증 사용자 처리

### DIFF
--- a/src/main/java/com/iglooclub/nungil/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/iglooclub/nungil/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,9 @@
 package com.iglooclub.nungil.config.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iglooclub.nungil.exception.ErrorResponse;
+import com.iglooclub.nungil.exception.TokenErrorResult;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -14,6 +18,13 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         // 유효한 자격증명을 제공하지 않고 접근하려 할 때 401 에러 반환
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        // 응답 값의 Body 설정
+        ErrorResponse errorResponse = ErrorResponse.create(TokenErrorResult.INVALID_AUTHENTICATION);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String responseBody = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(responseBody);
     }
 }

--- a/src/main/java/com/iglooclub/nungil/exception/ErrorResponse.java
+++ b/src/main/java/com/iglooclub/nungil/exception/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.iglooclub.nungil.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+
+    public static ErrorResponse create(ErrorResult errorResult) {
+        return new ErrorResponse(errorResult.name(), errorResult.getMessage());
+    }
+
+    public static ErrorResponse create(String code, String message) {
+        return new ErrorResponse(code, message);
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/iglooclub/nungil/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.iglooclub.nungil.exception;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
@@ -43,7 +41,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         log.warn("Invalid DTO Parameter errors : {}", errorList);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(HttpStatus.BAD_REQUEST.toString(), errorList.toString()));
+                .body(ErrorResponse.create(HttpStatus.BAD_REQUEST.toString(), errorList.toString()));
     }
 
     @ExceptionHandler({
@@ -64,18 +62,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<ErrorResponse> makeErrorResponseEntity(final ErrorResult errorResult, final String message) {
         return ResponseEntity.status(errorResult.getHttpStatus())
-                .body(new ErrorResponse(errorResult.name(), message));
+                .body(ErrorResponse.create(errorResult.name(), message));
     }
 
     private ResponseEntity<ErrorResponse> makeErrorResponseEntity(final ErrorResult errorResult) {
         return ResponseEntity.status(errorResult.getHttpStatus())
-                .body(new ErrorResponse(errorResult.name(), errorResult.getMessage()));
+                .body(ErrorResponse.create(errorResult));
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    static class ErrorResponse {
-        private final String code;
-        private final String message;
-    }
 }

--- a/src/main/java/com/iglooclub/nungil/exception/TokenErrorResult.java
+++ b/src/main/java/com/iglooclub/nungil/exception/TokenErrorResult.java
@@ -10,6 +10,8 @@ public enum TokenErrorResult implements ErrorResult {
 
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "Failed to find the refresh token in cookie"),
     UNEXPECTED_TOKEN(HttpStatus.BAD_REQUEST, "Given token is not valid"),
+    INVALID_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "Authentication failed for some reason. " +
+            "(e.g. expired or wrong access token, access token not found, etc.)")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 💜 작업 내용

인증되지 않은 사용자(e.g. 액세스 토큰이 없거나, 틀렸거나, 만료된 사용자)가
인증이 필요한 API를 요청한 경우, 프론트엔드로의 응답값에 에러 코드와 메시지 추가

## ✅ PR Point

- JwtAuthenticationEntryPoint는 인증이 실패한 경우, 이에 대한 처리를 하는 클래스
- GlobalExceptionHandler에서 수행하는, 응답값에 에러 코드와 메시지를 추가하는 작업을 해당 클래스에서 진행

```java
@Component
public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
    @Override
    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
        // 유효한 자격증명을 제공하지 않고 접근하려 할 때 401 에러 반환
        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
        response.setContentType("application/json;charset=UTF-8");

        // 응답 값의 Body 설정
        ErrorResponse errorResponse = ErrorResponse.create(TokenErrorResult.INVALID_AUTHENTICATION);
        ObjectMapper objectMapper = new ObjectMapper();
        String responseBody = objectMapper.writeValueAsString(errorResponse);
        response.getWriter().write(responseBody);
    }
}
```

## 😡 Trouble Shooting

1. 본래는 JwtAuthenticationEntryPoint 클래스의 파라미터로 있는 AuthenticationException 예외 클래스를 GlobalExceptionHandler 클래스에서 인식하고 예외 처리를 수행하려 했음
2. 하지만 JwtAuthenticationEntryPoint 클래스와 관련 기타 필터에서 에러를 처리하기 때문에, ExceptionHandler에서 예외를 받기 어려움
3. 이에 따라 ExceptionHandler에서 수행하는 ErrorResponse 클래스를 응답의 바디에 넣는 작업을, JwtAuthenticationEntryPoint 클래스에서 수행하도록 수정

## ☀ 스크린샷 / GIF / 화면 녹화

![image](https://github.com/Igloo-Club/Festival-BE/assets/50361496/297eba0b-fe8a-442a-ab34-17bf07bf722c)
